### PR TITLE
Add IMDb and TMDb button settings and functionality

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="service.discord.richpresence"
   name="Discord Rich Presence"
-  version="1.7.7"
+  version="1.7.8"
   provider-name="Hiumee">
 <requires>
   <import addon="xbmc.python" version="3.0.0"/>

--- a/default.py
+++ b/default.py
@@ -101,8 +101,101 @@ class ServiceRichPresence:
 
         self.settings['display_time'] = addon.getSettingBool('display_time')
 
+        self.settings['button_imdb_enabled'] = addon.getSettingBool('button_imdb_enabled')
+        self.settings['button_imdb_episode_link'] = addon.getSettingBool('button_imdb_episode_link')
+        self.settings['button_tmdb_enabled'] = addon.getSettingBool('button_tmdb_enabled')
+        self.settings['button_tmdb_episode_link'] = addon.getSettingBool('button_tmdb_episode_link')
+
         # get setting
         log(str(self.settings))
+
+    def getShowIds(self):
+        """Return (imdb_id, tmdb_id) for the currently playing TV show via Kodi JSON-RPC.
+        Uses VideoPlayer.TvShowDBID to look up the show in the library."""
+        show_imdb_id = None
+        show_tmdb_id = None
+        try:
+            show_dbid = xbmc.getInfoLabel('VideoPlayer.TvShowDBID')
+            if show_dbid and show_dbid.isdigit():
+                query = json.dumps({
+                    'jsonrpc': '2.0',
+                    'method': 'VideoLibrary.GetTVShowDetails',
+                    'params': {'tvshowid': int(show_dbid), 'properties': ['uniqueid']},
+                    'id': 1
+                })
+                result = json.loads(xbmc.executeJSONRPC(query))
+                unique_ids = result.get('result', {}).get('tvshowdetails', {}).get('uniqueid', {})
+                show_imdb_id = unique_ids.get('imdb') or None
+                show_tmdb_id = unique_ids.get('tmdb') or None
+                log('Show IDs (library): imdb={} tmdb={}'.format(show_imdb_id, show_tmdb_id))
+        except Exception as e:
+            log('getShowIds error: ' + str(e))
+        return show_imdb_id, show_tmdb_id
+
+    def buildButtons(self, data, media_type):
+        buttons = []
+
+        # Episode-level IDs from InfoLabels
+        imdb_id = None
+        tmdb_id = None
+        try:
+            unique_ids = data.getUniqueIDs()
+            imdb_id = unique_ids.get('imdb') or None
+            tmdb_id = unique_ids.get('tmdb') or None
+        except Exception:
+            imdb_id = xbmc.getInfoLabel('VideoPlayer.UniqueID(imdb)') or None
+            tmdb_id = xbmc.getInfoLabel('VideoPlayer.UniqueID(tmdb)') or None
+
+        # getIMDBNumber() returns tt-prefixed IMDb ID when available
+        raw_id = data.getIMDBNumber()
+        primary_imdb_id = raw_id if (raw_id and raw_id.startswith('tt')) else None
+
+        if not imdb_id and not tmdb_id:
+            imdb_id = primary_imdb_id
+
+        ep_link = media_type == 'episode'
+
+        # Fetch show-level IDs from library if any button needs them
+        # TMDb always needs the show ID for episodes (both show and episode URL formats use it)
+        show_imdb_id = None
+        show_tmdb_id = None
+        needs_show_ids = ep_link and (
+            (self.settings['button_imdb_enabled'] and not self.settings['button_imdb_episode_link']) or
+            self.settings['button_tmdb_enabled']
+        )
+        if needs_show_ids:
+            show_imdb_id, show_tmdb_id = self.getShowIds()
+
+        if self.settings['button_imdb_enabled']:
+            if ep_link and self.settings['button_imdb_episode_link']:
+                link_id = imdb_id  # episode-level
+            elif ep_link:
+                link_id = show_imdb_id or primary_imdb_id  # show-level
+            else:
+                link_id = imdb_id  # movie
+            if link_id:
+                buttons.append({
+                    'label': 'View on IMDb',
+                    'url': 'https://www.imdb.com/title/{}/'.format(link_id)
+                })
+
+        if self.settings['button_tmdb_enabled']:
+            if ep_link and self.settings['button_tmdb_episode_link']:
+                sid = show_tmdb_id or tmdb_id  # show ID required for episode URL
+                if sid:
+                    url = 'https://www.themoviedb.org/tv/{}/season/{}/episode/{}'.format(
+                        sid, data.getSeason(), data.getEpisode())
+                else:
+                    url = None
+            elif ep_link:
+                sid = show_tmdb_id or tmdb_id
+                url = 'https://www.themoviedb.org/tv/{}'.format(sid) if sid else None
+            else:
+                url = 'https://www.themoviedb.org/movie/{}'.format(tmdb_id) if tmdb_id else None
+            if url:
+                buttons.append({'label': 'View on TMDb', 'url': url})
+
+        return buttons[:2]  # Discord allows a maximum of 2 buttons
 
     def gatherData(self):
         player = xbmc.Player()
@@ -163,6 +256,11 @@ class ServiceRichPresence:
         details = self.getEpisodeDetails(data)
         if details:
             activity['details'] = details
+
+        buttons = self.buildButtons(data, 'episode')
+        if buttons:
+            activity['buttons'] = buttons
+
         return activity
 
     def getMovieState(self, data):
@@ -198,7 +296,12 @@ class ServiceRichPresence:
 
         details = self.getMovieDetails(data)
         if details:
-            activity['details'] = details 
+            activity['details'] = details
+
+        buttons = self.buildButtons(data, 'movie')
+        if buttons:
+            activity['buttons'] = buttons
+
         return activity
 
     def craftVideoState(self, data):

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -109,3 +109,7 @@ msgstr ""
 msgctxt "#32030"
 msgid "Link to episode (instead of show)"
 msgstr ""
+
+msgctxt "#32031"
+msgid "Link to episode (instead of show)"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -85,3 +85,27 @@ msgstr ""
 msgctxt "#32024"
 msgid "Use ID lookup - disable if name is correct but id is not TMDB or IMDB"
 msgstr ""
+
+msgctxt "#32025"
+msgid "Buttons"
+msgstr ""
+
+msgctxt "#32026"
+msgid "IMDb"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Show IMDb button"
+msgstr ""
+
+msgctxt "#32028"
+msgid "TMDb"
+msgstr ""
+
+msgctxt "#32029"
+msgid "Show TMDb button"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Link to episode (instead of show)"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -20,6 +20,6 @@
         <setting label="32030" type="bool" id="button_imdb_episode_link" default="false"/>
         <setting label="32028" type="lsep"/>
         <setting label="32029" type="bool" id="button_tmdb_enabled" default="false"/>
-        <setting label="32030" type="bool" id="button_tmdb_episode_link" default="false"/>
+        <setting label="32031" type="bool" id="button_tmdb_episode_link" default="false"/>
     </category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -14,4 +14,12 @@
         <setting label="32016" type="enum" id="episode_details" lvalues="32022|32021|32013|32017|32015"/>
         <setting label="32012" type="enum" id="episode_state" lvalues="32021|32022|32013|32017|32015"/>
     </category>
+    <category label="32025">
+        <setting label="32026" type="lsep"/>
+        <setting label="32027" type="bool" id="button_imdb_enabled" default="false"/>
+        <setting label="32030" type="bool" id="button_imdb_episode_link" default="false"/>
+        <setting label="32028" type="lsep"/>
+        <setting label="32029" type="bool" id="button_tmdb_enabled" default="false"/>
+        <setting label="32030" type="bool" id="button_tmdb_episode_link" default="false"/>
+    </category>
 </settings>


### PR DESCRIPTION
Closes [#22](https://github.com/Hiumee/service.discord.richpresence/issues/22)

## What's new

Adds optional IMDb and TMDb buttons to the Discord Rich Presence activity. Buttons are disabled by default and can be toggled individually in **Settings → Buttons**.

Note; You cannot see your own buttons, this is a Discord limitation. Only friends can see it. If you don't trust it, ask a friend if they see the buttons or check with another account.

### Settings added

| Setting | Description |
|---|---|
| Show IMDb button | Enables an IMDb button on the activity |
| Link to episode (IMDb) | Links to the specific episode page instead of the show page |
| Show TMDb button | Enables a TMDb button on the activity |
| Link to episode (TMDb) | Links to the specific episode page instead of the show page |

### How it works

- **Show links** (default): uses the show's IMDb/TMDb ID fetched from the Kodi library via JSON-RPC (`VideoLibrary.GetTVShowDetails`), so the button always links to the correct show page regardless of which scraper was used.
- **Episode links**: uses the episode-level IMDb ID from `VideoPlayer.UniqueID(imdb)` for IMDb, and builds a `/tv/{show_id}/season/{s}/episode/{e}` URL for TMDb using the show ID from the library.
- Movies always link directly to their movie page on both providers.
- Discord allows a maximum of 2 buttons, so enabling both IMDb and TMDb fills both slots.